### PR TITLE
Add support for ruby files

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,15 @@
         "extensions": [
           ".py"
         ]
+      },
+      {
+        "id": "ruby",
+        "aliases": [
+          "Ruby"
+        ],
+        "extensions": [
+          ".rb"
+        ]
       }
     ],
     "snippets": [
@@ -98,6 +107,10 @@
       {
         "language": "python",
         "path": "./snippets/pythonSnippets.json"
+      },
+      {
+        "language": "ruby",
+        "path": "./snippets/rubySnippets.json"
       }
     ]
   },

--- a/snippets/rubySnippets.json
+++ b/snippets/rubySnippets.json
@@ -1,0 +1,174 @@
+{
+	"comment": {
+		"prefix": "cc",
+		"body": [
+			"#**",
+			"# ${1}",
+			"#*"
+		],
+		"description": "comment code"
+	},
+	"apiDocumentation": {
+		"prefix": "apiDocumentation",
+		"body": [
+			"#**",
+			"# ",
+			"# @api {${1:method}} /${2:path} ${3:title}",
+			"# @apiName ${4:apiName}",
+			"# @apiGroup ${5:group}",
+			"# @apiVersion  ${6:major}.${7:minor}.${8:patch}",
+			"# ",
+			"# ",
+			"# @apiParam  {${9:String}} ${10:paramName} ${11:description}",
+			"# ",
+			"# @apiSuccess ${12:(${13:200})} {${14:type}} ${15:name} ${16:description}",
+			"# ",
+			"# @apiParamExample  {${17:type}} ${18:Request-Example:}",
+			"# {",
+			"#     ${19:property} : ${20:value}",
+			"# }",
+			"# ",
+			"# ",
+			"# @apiSuccessExample {${21:type}} ${22:Success-Response:}",
+			"# {",
+			"#     ${23:property} : ${24:value}",
+			"# }",
+			"# ",
+			"# ",
+			"#*"
+		],
+		"description": "ApiDoc Documentation"
+	},
+	"apiParam": {
+		"prefix": "apiParam",
+		"body": [
+			"@apiParam  {${String}} ${name} ${description}"
+		],
+		"description": "ApiDoc Parameter"
+	},
+	"apiSuccess": {
+		"prefix": "apiSuccess",
+		"body": [
+			"@apiSuccess ${group:(${code:200})} {${type}} ${name} ${description}"
+		],
+		"description": "ApiDoc Success"
+	},
+	"apiHeader": {
+		"prefix": "apiHeader",
+		"body": [
+			"@apiHeader ${group:(${code:200})} {${type}} ${field} ${description}"
+		],
+		"description": "ApiDoc Header"
+	},
+	"apiDeprecated": {
+		"prefix": "apiDeprecated",
+		"body": [
+			"@apiDeprecated ${text}"
+		],
+		"description": "ApiDoc Deprecated"
+	},
+	"apiDescription": {
+		"prefix": "apiDescription",
+		"body": [
+			"@apiDescription ${text}"
+		],
+		"description": "ApiDoc Description"
+	},
+	"api": {
+		"prefix": "apiApi",
+		"body": [
+			"@api {${method}} /${path} ${title}"
+		],
+		"description": "ApiDoc Api"
+	},
+	"apiName": {
+		"prefix": "apiName",
+		"body": [
+			"@apiName ${name}"
+		],
+		"description": "ApiDoc Name"
+	},
+	"apiGroup": {
+		"prefix": "apiGroup",
+		"body": [
+			"@apiGroup ${group}"
+		],
+		"description": "ApiDoc Group"
+	},
+	"apiUse": {
+		"prefix": "apiUse",
+		"body": [
+			"@apiUse ${name}"
+		],
+		"description": "ApiDoc Use"
+	},
+	"apiVersion": {
+		"prefix": "apiVersion",
+		"body": [
+			"@apiVersion  ${major}.${minor}.${patch}"
+		],
+		"description": "ApiDoc Version"
+	},
+	"apiDefine": {
+		"prefix": "apiDefine",
+		"body": [
+			"@apiDefine ${name} ${title}",
+			"*    ${description} "
+		],
+		"description": "ApiDoc Define"
+	},
+	"apiErrorExample": {
+		"prefix": "apiErrorExample",
+		"body": [
+			"@apiErrorExample {${type}} ${title:Error-Response:}",
+			"    ${example}"
+		],
+		"description": "ApiDoc Error Example"
+	},
+	"apiParamExample": {
+		"prefix": "apiParamExample",
+		"body": [
+			"@apiParamExample  {${type}} ${title:Request-Example:}",
+			"*    ${example}"
+		],
+		"description": "ApiDoc Param Example"
+	},
+	"apiSuccessExample": {
+		"prefix": "apiSuccessExample ",
+		"body": [
+			"@apiSuccessExample {${type}} ${title:Success-Response:}",
+			"*    ${example}"
+		],
+		"description": "ApiDoc Param Example"
+	},
+	"apiHeaderExample": {
+		"prefix": "apiHeaderExample",
+		"body": [
+			"@apiHeaderExample {${type}} ${title:Request-Example:}",
+			"*    ${example}"
+		],
+		"description": "ApiDoc Header Example"
+	},
+	"apiExample": {
+		"prefix": "apiExample",
+		"body": [
+			"@apiExample {${type}} ${title:Example usage:}",
+			"*    ${example}"
+		],
+		"description": "ApiDoc Error Example"
+	},
+	"apiSampleRequest": {
+		"prefix": "apiSampleRequest",
+		"body": [
+			"@apiSampleRequest ${url}"
+		],
+		"description": "ApiDoc Sample Request"
+	},
+	"apiPermission": {
+		"prefix": "apiPermission",
+		"body": [
+			"@apiPermission ${name}"
+		],
+		"description": "ApiDoc Permission"
+	}
+}


### PR DESCRIPTION
I use ApiDoc to document my API and wanted to use apidoc vscode extension but I discover it does not support Ruby files.

So here it is!